### PR TITLE
Re-Enable Scout Comparisons Now That There's Something to Compare To

### DIFF
--- a/.github/workflows/docker-ci-pr.yml
+++ b/.github/workflows/docker-ci-pr.yml
@@ -234,71 +234,71 @@ jobs:
           - name: Scout i386
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/386
               only-fixed: true
 
           - name: Scout AMD64
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/amd64
               only-fixed: true
 
           - name: Scout ARMV5
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/arm/v5
               only-fixed: true
 
           - name: Scout ARMV7
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/arm/v7
               only-fixed: true
 
           - name: Scout ARM64
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/arm64
               only-fixed: true
 
           - name: Scout PPC64
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/ppc64le
               only-fixed: true
 
           - name: Scout RISCV64
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/riscv64
               only-fixed: true
 
           - name: Scout s390x
             uses: docker/scout-action@v1
             with:
-              command: quickview,cves,recommendations
+              command: quickview,cves,recommendations,compare
               image: ghcr.io/jlp04/elevation-generator:test
-              # to: jlp04/elevation-generator:latest
+              to: jlp04/elevation-generator:latest
               platform: linux/s390x
               only-fixed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt --no-install-recommends
 
 RUN set -o pipefail && curl https://getcroc.schollz.com | bash || curl https://getcroc.schollz.com | sed 's^croc_base_url="https://github.com/schollz/croc/releases/download"^croc_base_url="file://"^g' | bash
 
-RUN rm -R /v$CROC_VERSION
+RUN rm -R /v$CROC_VERSION /tmp/*
 
 RUN useradd --no-log-init -r -m -u 999 -g sudo user
 


### PR DESCRIPTION
This re-enables Docker Scout comparisons to the latest stable image when rebuilding. It also removes tmpfiles left over from `croc` installation that were causing security advisories (which had non-deterministic file paths and thus were different for each architecture). 