### PR TITLE
No Longer Switch to a New User At End of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,13 +242,9 @@ RUN set -o pipefail && curl https://getcroc.schollz.com | bash || curl https://g
 
 RUN rm -R /v$CROC_VERSION /tmp/*
 
-RUN useradd --no-log-init -r -m -u 999 -g sudo user
-
-USER user:sudo
-
 RUN mkdir -p ~/.fgfs/TerraSync
 
-VOLUME ["/home/user/.fgfs/TerraSync"]
+VOLUME ["/root/.fgfs/TerraSync"]
 
 WORKDIR /ATC-pie-$ATC_PIE_VERSION
 


### PR DESCRIPTION
This removes the switch to a new user at the end of the Dockerfile. This was originally done to clarify where the volume for scenery should be placed, but it made it so that if one opened a shell inside the container, one couldn't run any commands that required superuser privileges. 