### PR TITLE
Try to Fix Seemingly Missing Build Attestations

### DIFF
--- a/.github/workflows/docker-ci-pr.yml
+++ b/.github/workflows/docker-ci-pr.yml
@@ -57,6 +57,8 @@ jobs:
               with:
                 images: ${{ env.GITHUB_IMAGE_NAME }}
                 tags: type=raw,test
+              env:
+                DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
               
             - name: Rename meta bake definition file
               run: |

--- a/.github/workflows/docker-ci-push.yml
+++ b/.github/workflows/docker-ci-push.yml
@@ -55,6 +55,8 @@ jobs:
               with:
                 images: ${{ env.GITHUB_IMAGE_NAME }}
                 tags: type=raw,main
+              env:
+                DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
               
             - name: Rename meta bake definition file
               run: |


### PR DESCRIPTION
For some reason, it looks like build attestations aren't working properly. This PR attempts to fix that by storing them in the index, besides just storing them in the manifest. 