### PR TITLE
Update `croc` to Version 11.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ATC_PIE_VERSION=1.10.1
-ARG CROC_VERSION=11.0.1
+ARG CROC_VERSION=11.0.2
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 FROM debian:latest AS build
@@ -226,7 +226,16 @@ FROM debian:latest AS build-go
 
 ARG CROC_VERSION
 
-ENV GO_VERSION=1.24
+ENV GO_VERSION=1.26
+
+COPY --link <<"EOF" /etc/apt/sources.list.d/debian-backports.sources
+Types: deb deb-src
+URIs: http://deb.debian.org/debian
+Suites: trixie-backports
+Components: main
+Enabled: yes
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt --no-install-recommends install -y golang-$GO_VERSION-go git ca-certificates && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
@@ -236,12 +245,12 @@ WORKDIR /croc-v$CROC_VERSION
 
 ENV CGO_ENABLED=0
 
-ENV LDFLAGS='-extldflags "-static"'
+ENV LDFLAGS='-s -w -buildid= -extldflags "-static"'
 
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-RUN --mount=type=cache,target=/root/.cache/go-build,id=cache-go-$TARGETARCH-$TARGETVARIANT /usr/lib/go-$GO_VERSION/bin/go build -ldflags "$LDFLAGS" -o croc
+RUN --mount=type=cache,target=/root/.cache/go-build,id=cache-go-$TARGETARCH-$TARGETVARIANT /usr/lib/go-$GO_VERSION/bin/go build -buildvcs=false -trimpath -tags netgo,osusergo -ldflags "$LDFLAGS" -o croc
 
 RUN rm -rf /root/.cache/go-build/*
 


### PR DESCRIPTION
Update `croc` to version 11.0.2 and update how we build `croc` to align with upstream release CI, including switching back to using `go` version 1.26. 